### PR TITLE
Fix missing quotes

### DIFF
--- a/djangocms_translations/forms.py
+++ b/djangocms_translations/forms.py
@@ -73,9 +73,7 @@ class ChooseTranslationQuoteForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
-        self.base_fields['selected_quote'].queryset = (
-            self.base_fields['selected_quote'].queryset
-            .filter(request=kwargs['instance'])
-        )
         super(ChooseTranslationQuoteForm, self).__init__(*args, **kwargs)
-        self.fields['selected_quote'].choices = list(self.fields['selected_quote'].choices)[1:]
+        self.fields['selected_quote'].required = True
+        self.fields['selected_quote'].queryset = self.instance.quotes.all()
+        self.fields['selected_quote'].empty_label = None


### PR DESCRIPTION
Fixes a bug where the quotes would not appear after a while. The problem
was the setting of ``self.base_fields`` on the ``ModelForm``. ``self.base_fields``
is shared by all instances of the ``Form``, so it leaks to other requests.
So the ``choices`` were only displayed correctly once per django process.

This also sets ``empty_label`` to ``None`` instead of removing the first choice,
which is unreliable.

Setting ``required=True`` shows a correct form validation error when the 
user submits the form without selecting anything (previously it threw a
500 error).

Fixes IDX-204