### PR TITLE
Fix sending Supertext request

### DIFF
--- a/djangocms_translations/providers/supertext.py
+++ b/djangocms_translations/providers/supertext.py
@@ -199,6 +199,7 @@ class SupertextTranslationProvider(BaseTranslationProvider):
         if request.selected_quote:
             data.update(request.selected_quote.provider_options)
 
+        # Enables retrying requests to Supertext after error from Supertext API
         order, created = TranslationOrder.objects.get_or_create(
             request=request,
             defaults={'request_content': data}


### PR DESCRIPTION
When retrying sending translation request occured error because of
creating another translation order instance.